### PR TITLE
Fix returning name

### DIFF
--- a/analysis/study_definition_cohort.py
+++ b/analysis/study_definition_cohort.py
@@ -106,7 +106,7 @@ study = StudyDefinition(
     **demographic_variables,
     msoa=patients.registered_practice_as_of(
         "index_date",
-        returning="msoa",
+        returning="msoa_code",
         return_expectations={
             "rate": "universal",
             "category": {


### PR DESCRIPTION
`msoa` only works in TPP currently, `msoa_code` should work in both