### PR TITLE
include crosstabs for incorrect and correct IMD groups

### DIFF
--- a/analysis/all_time_counts.py
+++ b/analysis/all_time_counts.py
@@ -80,7 +80,7 @@ first_covid_date = df[["sgss_positive", "primary_care_covid", "hospital_covid"]]
 ## Crosstabs
 crosstabs = [crosstab(df[v]) for v in stratifiers]
 all_together = pd.concat(
-    crosstabs, axis=0, keys=stratifiers + ["imd"], names=["Attribute", "Category"]
+    crosstabs, axis=0, keys=stratifiers + ["imdQ5_incorrect", "imdQ5_correct"], names=["Attribute", "Category"]
 )
 print(all_together)
 redact_small_numbers(all_together, "Long COVID").to_csv("output/counts_table.csv")

--- a/analysis/common_variables.py
+++ b/analysis/common_variables.py
@@ -58,26 +58,49 @@ demographic_variables = dict(
             },
         },
     ),
-    imd=patients.categorised_as(
+    imd=patients.address_as_of(
+        "index_date",
+        returning="index_of_multiple_deprivation",
+        round_to_nearest=100,
+    ),
+    imdQ5_incorrect=patients.categorised_as(
         {
-            "0": "DEFAULT",
-            "1": """index_of_multiple_deprivation >=1 AND index_of_multiple_deprivation < 32844*1/5""",
-            "2": """index_of_multiple_deprivation >= 32844*1/5 AND index_of_multiple_deprivation < 32844*2/5""",
-            "3": """index_of_multiple_deprivation >= 32844*2/5 AND index_of_multiple_deprivation < 32844*3/5""",
-            "4": """index_of_multiple_deprivation >= 32844*3/5 AND index_of_multiple_deprivation < 32844*4/5""",
-            "5": """index_of_multiple_deprivation >= 32844*4/5 AND index_of_multiple_deprivation < 32844""",
+            "Unknown": "DEFAULT",
+            "1 (most deprived)": """imd >=1 AND imd < 32844*1/5""",
+            "2": """imd >= 32844*1/5 AND imd < 32844*2/5""",
+            "3": """imd >= 32844*2/5 AND imd < 32844*3/5""",
+            "4": """imd >= 32844*3/5 AND imd < 32844*4/5""",
+            "5 (least deprived)": """imd >= 32844*4/5 AND imd <= 32844""",
         },
-        index_of_multiple_deprivation=patients.address_as_of(
-            "index_date",
-            returning="index_of_multiple_deprivation",
-            round_to_nearest=100,
-        ),
         return_expectations={
             "rate": "universal",
             "category": {
                 "ratios": {
                     "0": 0.05,
                     "1": 0.19,
+                    "2": 0.19,
+                    "3": 0.19,
+                    "4": 0.19,
+                    "5": 0.19,
+                }
+            },
+        },
+    ),
+    imdQ5_correct=patients.categorised_as(
+        {
+            "Unknown": "DEFAULT",
+            "1 (most deprived)": """imd >=0 AND imd < 32844*1/5""",
+            "2": """imd >= 32844*1/5 AND imd < 32844*2/5""",
+            "3": """imd >= 32844*2/5 AND imd < 32844*3/5""",
+            "4": """imd >= 32844*3/5 AND imd < 32844*4/5""",
+            "5 (least deprived)": """imd >= 32844*4/5 AND imd <= 32844""",
+        },
+        return_expectations={
+            "rate": "universal",
+            "category": {
+                "ratios": {
+                    "0": 0.04,
+                    "1": 0.20,
                     "2": 0.19,
                     "3": 0.19,
                     "4": 0.19,

--- a/analysis/common_variables.py
+++ b/analysis/common_variables.py
@@ -89,12 +89,12 @@ demographic_variables = dict(
             "rate": "universal",
             "category": {
                 "ratios": {
-                    "0": 0.05,
-                    "1": 0.19,
+                    "Unknown": 0.05,
+                    "1 (most deprived)": 0.19,
                     "2": 0.19,
                     "3": 0.19,
                     "4": 0.19,
-                    "5": 0.19,
+                    "5 (least deprived)": 0.19,
                 }
             },
         },
@@ -112,12 +112,12 @@ demographic_variables = dict(
             "rate": "universal",
             "category": {
                 "ratios": {
-                    "0": 0.04,
-                    "1": 0.20,
+                    "Unknown": 0.04,
+                    "1 (most deprived)": 0.20,
                     "2": 0.19,
                     "3": 0.19,
                     "4": 0.19,
-                    "5": 0.19,
+                    "5 (least deprived)": 0.19,
                 }
             },
         },

--- a/analysis/common_variables.py
+++ b/analysis/common_variables.py
@@ -62,6 +62,19 @@ demographic_variables = dict(
         "index_date",
         returning="index_of_multiple_deprivation",
         round_to_nearest=100,
+        return_expectations={
+            "rate": "universal",
+            "category": {
+                "ratios": {
+                    "-1": 0.05,
+                    "100": 0.19,
+                    "200": 0.19,
+                    "300": 0.19,
+                    "400": 0.19,
+                    "500": 0.19,
+                }
+            },
+        },
     ),
     imdQ5_incorrect=patients.categorised_as(
         {


### PR DESCRIPTION
* Redo how IMD is extracted and grouped in the study definition. 
* Use two definitions of grouped IMD, either including or excluding `imd=0` in the "highest deprivation" group
* Include both definitions in the script `all_time_counts.csv`, which corss-tabs long-covid status with other demographic variables